### PR TITLE
Implement Convert for Activations and Optimisers

### DIFF
--- a/.github/ISSUE_TEMPLATE/api_changed.md
+++ b/.github/ISSUE_TEMPLATE/api_changed.md
@@ -1,0 +1,21 @@
+---
+name: External API changes
+about: Use this template if the code requires modification due to api changes of any referenced library. Including other BHoM dlls
+labels: "type:external-api-changes"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Parent issue(s) or Pull Request(s) causing the changes:
+<!-- If appropriate please reference the url of any other issue(s) that forces the current change-->
+<!-- Note: that this is usually a change in an external API -->
+
+#
+
+#### Description:
+<!-- Add a brief description -->
+
+
+#### Test file(s):
+<!-- Link to test files to validate the proposed changes -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug
+about: Use this template if an implementation provides incorrect results or causes crashes.
+labels: "type:bug"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Description:
+<!-- Add a brief description -->
+
+
+#### How to replicate:
+<!-- Describe a routine that allows developers to replicate the issue -->
+
+
+#### Expected behaviour:
+<!-- What result would you expect from the fix? -->
+
+
+#### Test file(s):
+<!-- Link to test files to validate the proposed changes -->

--- a/.github/ISSUE_TEMPLATE/compliance.md
+++ b/.github/ISSUE_TEMPLATE/compliance.md
@@ -1,0 +1,15 @@
+---
+name: Compliance
+about: Use this template to report code that doesn't follow the guidelines.
+labels: "type:compliance"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Broken rules:
+<!-- Add a brief description of what is incorrect or missing -->
+
+
+#### Suggestions to restore compliance:
+<!-- Any guidance or suggestion on how to bring the element back to compliance -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,15 @@
+---
+name: Documentation
+about: Use this template to report missing or incorrect documentation in the code or in the wiki.
+labels: "type:documentation"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Describe the documentation issue:
+- [ ] The code - the attribute of a method or class
+- [ ] The wiki
+
+#### What is missing/incorrect?
+<!-- Details of desired documentation? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Use this template to request a functionality that doesn't exist yet or is only partially implemented.
+labels: "type:feature"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Description:
+<!-- Add a brief description of what functionality is missing, including sufficient details of expected behaviour -->
+
+
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: https://bhom.slack.com/ can the right place for general questions. Use this template only if you have a specific question about the code or a procedure.
+labels: "type:question"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+<!-- If you need to ask on slack, you can use this link
+https://join.slack.com/t/bhom/shared_invite/enQtNTQzNjkyNzIzMjM1LTU4NDE1OTJhZDk4NjFmNDkwYWQ0NDIwNTNhMjZmMGQwMjhiMTZlMDdiMTgwMzEzMDhlODdjMDVkZmE5MjI1OTQ -->

--- a/.github/ISSUE_TEMPLATE/test_script.md
+++ b/.github/ISSUE_TEMPLATE/test_script.md
@@ -1,0 +1,11 @@
+---
+name: Test script
+about: Use this template to create an automatic, regular check on a part of the code.
+labels: "type:test-script"
+
+---
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH ISSUE CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+#### Area of the code or method(s) to be covered:
+<!-- Describe the breadth of the proposed coverage -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
+<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
+
+### NOTE: Depends on 
+<!-- Link to any additional PRs in other repos required for this PR to function -->
+<!-- Delete if not required -->
+
+   
+### Issues addressed by this PR
+<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
+
+Closes #
+
+<!-- Add short description of what has been fixed -->
+
+
+### Test files
+<!-- Link to test files to validate the proposed changes -->
+
+
+### Changelog
+<!-- Text to go into changelog if applicable -->
+<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
+
+
+### Additional comments
+<!-- As required -->

--- a/Keras/Layers/Activations.cs
+++ b/Keras/Layers/Activations.cs
@@ -1,9 +1,29 @@
-﻿using System;
+﻿using Python.Runtime;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Keras.Layers
 {
+    /// <summary>
+    /// Applies an activation function to an output.
+    /// </summary>
+    /// <seealso cref="Keras.Layers.BaseLayer" />
+    public class Activation : BaseLayer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeakyReLU"/> class.
+        /// </summary>
+        /// <param name="alpha">float >= 0. Negative slope coefficient.</param>
+        public Activation(PyObject activation)
+        {
+            Parameters["activation"] = activation;
+
+            PyInstance = Keras.keras.layers.Activation;
+            Init();
+        }
+    }
+
     /// <summary>
     /// Leaky version of a Rectified Linear Unit.
     /// It allows a small gradient when the unit is not active: f(x) = alpha* x for x< 0, f(x) = x for x >= 0.
@@ -38,7 +58,7 @@ namespace Keras.Layers
         /// <param name="alpha_regularizer">regularizer for the weights.</param>
         /// <param name="alpha_constraint">constraint for the weights.</param>
         /// <param name="shared_axes">the axes along which to share learnable parameters for the activation function. For example, if the incoming feature maps are from a 2D convolution with output shape (batch, height, width, channels), and you wish to share parameters across space so that each filter only has one set of parameters, set shared_axes=[1, 2].</param>
-        public PReLU(string alpha_initializer= "zeros", string alpha_regularizer= "", string alpha_constraint= "", int[] shared_axes= null)
+        public PReLU(string alpha_initializer = "zeros", string alpha_regularizer = "", string alpha_constraint = "", int[] shared_axes = null)
         {
             Parameters["alpha_initializer"] = alpha_initializer;
             Parameters["alpha_regularizer"] = alpha_regularizer;
@@ -110,6 +130,42 @@ namespace Keras.Layers
     }
 
     /// <summary>
+    /// Softmax activation function with logits. Uses the log-sum-exp trick for numerical stability.
+    /// </summary>
+    /// <seealso cref="Keras.Layers.BaseLayer" />
+    public class LogSoftmax : BaseLayer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Softmax" /> class.
+        /// </summary>
+        /// <param name="axis"> Integer, axis along which the softmax normalization is applied.</param>
+        public LogSoftmax(int axis = -1)
+        {
+            Activation activation = new Activation(Keras.tensorflow.nn.log_softmax);
+
+            PyInstance = activation.PyInstance;
+        }
+    }
+
+    /// <summary>
+    /// Sigmoid activation function with logits. Uses the log-sum-exp trick for numerical stability.
+    /// </summary>
+    /// <seealso cref="Keras.Layers.BaseLayer" />
+    public class LogSigmoid : BaseLayer
+    {
+        /// <summary>
+        /// Initializes a new instance oyeah f the <see cref="Softmax" /> class.
+        /// </summary>
+        /// <param name="axis"> Integer, axis along which the softmax normalization is applied.</param>
+        public LogSigmoid()
+        {
+            Activation activation = new Activation(Keras.tensorflow.math.log_sigmoid);
+
+            PyInstance = activation.PyInstance;
+        }
+    }
+
+    /// <summary>
     /// Rectified Linear Unit activation function.
     /// With default values, it returns element-wise max(x, 0). 
     /// Otherwise, it follows: f(x) = max_value for x >= max_value, f(x) = x for threshold &lt;= x<max_value, f(x) = negative_slope* (x - threshold) otherwise.
@@ -123,7 +179,7 @@ namespace Keras.Layers
         /// <param name="max_value">float >= 0. Maximum activation value.</param>
         /// <param name="negative_slope">float >= 0. Negative slope coefficient.</param>
         /// <param name="threshold">float. Threshold value for thresholded activation.</param>
-        public ReLU(float? max_value= null, float negative_slope= 0, float threshold= 0)
+        public ReLU(float? max_value = null, float negative_slope = 0, float threshold = 0)
         {
             Parameters["max_value"] = max_value;
             Parameters["negative_slope"] = negative_slope;
@@ -144,10 +200,8 @@ namespace Keras.Layers
         /// </summary>
         public Sigmoid()
         {
-            Parameters["activation"] = Keras.keras.activations.sigmoid;
-
-            PyInstance = Keras.keras.layers.Activation;
-            Init();            
+            Activation activation = new Activation(Keras.keras.activations.sigmoid);
+            PyInstance = activation.PyInstance;
         }
     }
 
@@ -161,10 +215,8 @@ namespace Keras.Layers
         /// </summary>
         public Tanh()
         {
-            Parameters["activation"] = Keras.keras.activations.tanh;
-
-            PyInstance = Keras.keras.layers.Activation;
-            Init();
+            Activation activation = new Activation(Keras.keras.activations.tanh);
+            PyInstance = activation.PyInstance;
         }
     }
 }

--- a/Keras/Layers/Core.cs
+++ b/Keras/Layers/Core.cs
@@ -79,26 +79,6 @@
     }
 
     /// <summary>
-    /// Applies an activation function to an output.
-    /// </summary>
-    /// <seealso cref="Keras.Layers.BaseLayer" />
-    public class Activation : BaseLayer
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Activation"/> class.
-        /// </summary>
-        /// <param name="act">name of activation function to use (see: activations), or alternatively, a Theano or TensorFlow operation.</param>
-        /// <param name="input_shape">Arbitrary. Use the keyword argument input_shape (tuple of integers, does not include the samples axis) when using this layer as the first layer in a model.</param>
-        public Activation(string act, Shape input_shape = null)
-        {
-            Parameters["activation"] = act;
-            Parameters["input_shape"] = input_shape;
-            PyInstance = Keras.keras.layers.Activation;
-            Init();
-        }
-    }
-
-    /// <summary>
     /// Applies Dropout to the input.
     /// Dropout consists in randomly setting a fraction rate of input units to 0 at each update during training time, which helps prevent overfitting.
     /// </summary>

--- a/Keras_Engine/Convert/FromKeras.cs
+++ b/Keras_Engine/Convert/FromKeras.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.Keras
 
         public static Reduce FromKeras(string reduction)
         {
-            switch(reduction)
+            switch (reduction)
             {
                 case "auto":
                     return Reduce.Sum;
@@ -78,6 +78,7 @@ namespace BH.Engine.Keras
                     return Reduce.No;
             }
         }
+
 
         /***************************************************/
         /**** Public Methods - Activations              ****/
@@ -93,17 +94,35 @@ namespace BH.Engine.Keras
 
         /***************************************************/
 
-        public static ReLU FromKeras(this k.Layers.ReLU leakyRelu)
+        public static LogSigmoid FromKeras(this k.Layers.LogSigmoid logSigmoid)
+        {
+            return new LogSigmoid();
+        }
+
+        /***************************************************/
+
+        public static LogSoftmax FromKeras(this k.Layers.LogSoftmax logSoftmax)
+        {
+            return new LogSoftmax()
+            {
+                // This is not possible since tf.nn.log_softmax is a function and does not store parameters
+                //Dimension = (int)logSoftmax.Parameters["axis"]  
+            };
+        }
+
+        /***************************************************/
+
+        public static ReLU FromKeras(this k.Layers.ReLU relu)
         {
             return new ReLU();
         }
 
         /***************************************************/
 
-        //public static Sigmoid FromKeras(this k.Layers.Sigmoid leakyRelu)
-        //{
-        //    return new Sigmoid();
-        //}
+        public static Sigmoid FromKeras(this k.Layers.Sigmoid sigmoid)
+        {
+            return new Sigmoid();
+        }
 
         /***************************************************/
 
@@ -117,11 +136,10 @@ namespace BH.Engine.Keras
 
         /***************************************************/
 
-        //public static Tanh FromKeras(this k.Layers.Tanh tanh)
-        //{
-        //    return new Tanh();
-        //}
-
+        public static Tanh FromKeras(this k.Layers.Tanh tanh)
+        {
+            return new Tanh();
+        }
 
 
         /***************************************************/
@@ -140,7 +158,7 @@ namespace BH.Engine.Keras
 
         public static BinaryCrossEntropy FromKeras(this k.Layers.BinaryCrossentropy bce)
         {
-            return new BinaryCrossEntropy() 
+            return new BinaryCrossEntropy()
             {
                 Reduce = FromKeras((bce.Parameters["reduction"] as string)),
             };
@@ -177,7 +195,7 @@ namespace BH.Engine.Keras
         }
 
         /***************************************************/
-        
+
         public static NegativeLogLikelihood FromKeras(this k.Layers.NegLogLikelihood nll)
         {
             return new NegativeLogLikelihood()
@@ -290,7 +308,7 @@ namespace BH.Engine.Keras
             Engine.Reflection.Compute.RecordError($"No Convert method found for {fallback?.GetType()}");
             return null;
         }
-        
+
         /***************************************************/
     }
 }

--- a/Keras_Engine/Convert/FromKeras.cs
+++ b/Keras_Engine/Convert/FromKeras.cs
@@ -28,6 +28,7 @@ using BH.oM.DeepLearning.Activations;
 using System.Linq;
 using BH.oM.DeepLearning;
 using BH.oM.DeepLearning.Losses;
+using BH.oM.DeepLearning.Optimisers;
 
 namespace BH.Engine.Keras
 {
@@ -295,6 +296,33 @@ namespace BH.Engine.Keras
                 Padding = (string)transposedConv2d.Parameters["padding"] == "same" ? new Shape2d { Dim1 = 1, Dim2 = 1 } : new Shape2d { Dim1 = 0, Dim2 = 0 },
                 Dilation = ((k.Shape)transposedConv2d.Parameters["dilation_rate"]).FromKeras() as Shape2d,
                 OutputSize = outSize,
+            };
+        }
+        /***************************************************/
+        /**** Public Methods - Optimisers               ****/
+        /***************************************************/
+
+        public static SGD FromKeras(this k.Optimizers.SGD sgd)
+        {
+            return new SGD()
+            {
+                LearningRate = (double)sgd.Parameters["lr"],
+                Momentum = (double)sgd.Parameters["momentum"],
+                Nesterov = (bool)sgd.Parameters["nesterov"],
+                WeightDecay = (double)sgd.Parameters["decay"]
+            };
+        }
+
+        /***************************************************/
+
+        public static Adam FromKeras(this k.Optimizers.Adam adam)
+        {
+            return new Adam()
+            {
+                LearningRate = (double)adam.Parameters["lr"],
+                Beta1 = (double)adam.Parameters["beta_1"],
+                Beta2 = (double)adam.Parameters["beta_2"],
+                WeightDecay = (double)adam.Parameters["decay"]
             };
         }
 

--- a/Keras_Engine/Convert/ToKeras.cs
+++ b/Keras_Engine/Convert/ToKeras.cs
@@ -133,9 +133,44 @@ namespace BH.Engine.Keras
 
         /***************************************************/
 
+        public static k.Layers.LogSigmoid ToKeras(this LogSigmoid logSigmoid)
+        {
+            return new k.Layers.LogSigmoid();
+        }
+
+        /***************************************************/
+
+        public static k.Layers.LogSoftmax ToKeras(this LogSoftmax logSoftmax)
+        {
+            return new k.Layers.LogSoftmax(logSoftmax.Dimension);
+        }
+
+        /***************************************************/
+
         public static k.Layers.ReLU ToKeras(this ReLU relu)
         {
             return new k.Layers.ReLU();
+        }
+
+        /***************************************************/
+
+        public static k.Layers.Sigmoid ToKeras(this Sigmoid sigmoid)
+        {
+            return new k.Layers.Sigmoid();
+        }
+
+        /***************************************************/
+
+        public static k.Layers.Softmax ToKeras(this Softmax softmax)
+        {
+            return new k.Layers.Softmax(softmax.Dimension);
+        }
+
+        /***************************************************/
+
+        public static k.Layers.Tanh ToKeras(this Tanh tanh)
+        {
+            return new k.Layers.Tanh();
         }
 
 

--- a/Keras_Engine/Convert/ToKeras.cs
+++ b/Keras_Engine/Convert/ToKeras.cs
@@ -26,6 +26,7 @@ using BH.oM.DeepLearning;
 using BH.oM.DeepLearning.Layers;
 using BH.oM.DeepLearning.Activations;
 using BH.oM.DeepLearning.Losses;
+using BH.oM.DeepLearning.Optimisers;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -289,6 +290,23 @@ namespace BH.Engine.Keras
                 strides: transposedConv2d.Stride.ToTuple(),
                 padding: transposedConv2d.Padding.Dim1 == 0 && transposedConv2d.Padding.Dim2 == 0 ? "valid" : "same",
                 dilation_rate: transposedConv2d.Dilation.ToTuple());
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Optimisers               ****/
+        /***************************************************/
+
+        public static k.Optimizers.SGD ToBHoM(this SGD sgd)
+        {
+            return new k.Optimizers.SGD((float)sgd.LearningRate, (float)sgd.Momentum, (float)sgd.WeightDecay, sgd.Nesterov);
+        }
+
+        /***************************************************/
+
+        public static k.Optimizers.Adam ToBHom(Adam adam)
+        {
+            return new k.Optimizers.Adam((float)adam.LearningRate, (float)adam.Beta1, (float)adam.Beta2, null, (float)adam.WeightDecay, false);
         }
 
         /***************************************************/


### PR DESCRIPTION
Closes #10 
Closes #8 

#### Change log
- Add Convert.FromKeras and Convert.ToKeras for:
  - LeakyReLU
  - LogSigmoid
  - LogSoftmax
  - ReLU
  - Sigmoid
  - Softmax
  - Tanh
  - Adam
  - SGD

#### Test file
https://burohappold.sharepoint.com/:f:/s/BHoM/EtM_cCW6kR9Jkan8fC-IS_MBFP9Ydurjkg9HU-K24yuLsg?e=8yqRuP


#### Additional comments
The Convert for `LogSoftmax` at this moment does not allow passing the `axis`/`Dimension` parameter through because of the way `tensorflow` treats the `tf.nn.log_softmax` object, which is passed a `function`

@AlaaAlfakara Would you mind start testing these things? I think it is useful if start familiarising with it, such that I can have feedback on what works and what not.